### PR TITLE
Small fixes for asciidoc rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- \[AsciiDoc] Support for underlined text (#74)
+
+### Fixed
+
+- \[AsciiDoc] No line breaks inside paragraph (#73)
+
 ## 0.12.0 - 2023-08-26
 
 ### Added

--- a/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/AsciidocParser.kt
+++ b/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/AsciidocParser.kt
@@ -17,10 +17,12 @@ class AsciidocParser(
         private val TEMPLATES_LOCATION = "/com/github/zeldigas/text2confl/asciidoc"
     }
 
-    private val ADOC: Asciidoctor = Asciidoctor.Factory.create().also {asciidoc ->
-        config.libsToLoad.forEach { asciidoc.requireLibrary(it)}
-        if (config.loadBundledMacros) {
-            DefaultMacros().register(asciidoc)
+    private val ADOC: Asciidoctor by lazy {
+        Asciidoctor.Factory.create().also { asciidoc ->
+            config.libsToLoad.forEach { asciidoc.requireLibrary(it) }
+            if (config.loadBundledMacros) {
+                DefaultMacros().register(asciidoc)
+            }
         }
     }
 

--- a/convert/src/main/resources/com/github/zeldigas/text2confl/asciidoc/block_paragraph.html.slim
+++ b/convert/src/main/resources/com/github/zeldigas/text2confl/asciidoc/block_paragraph.html.slim
@@ -4,4 +4,4 @@
 p
   - if id
     = anchor(id)
-  =content
+  =adjusted_paragraph_content

--- a/convert/src/main/resources/com/github/zeldigas/text2confl/asciidoc/helpers.rb
+++ b/convert/src/main/resources/com/github/zeldigas/text2confl/asciidoc/helpers.rb
@@ -256,6 +256,8 @@ module Slim::Helpers
         %(#{open.chop} class="#{node.role}">#{node.text}#{close})
       elsif node.role == 'line-through'
         %(<del>#{node.text}</del>)
+      elsif node.role == 'underline'
+        %(<u>#{node.text}</u>)
       else
         %(<span class="#{node.role}">#{open}#{node.text}#{close}</span>)
       end
@@ -279,6 +281,10 @@ module Slim::Helpers
     else
       document.attr 't2c-editor-version'
     end
+  end
+
+  def adjusted_paragraph_content
+    content.gsub(Asciidoctor::LF, ' ')
   end
 
 

--- a/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfAdmonitionTest.kt
+++ b/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfAdmonitionTest.kt
@@ -15,6 +15,8 @@ internal class RenderingOfAdmonitionTest : RenderingTestBase() {
             [$type]
             ====
             Test block **with** formatting
+            and line breaks
+            in paragraph
             
             1. and
             2. lists
@@ -25,7 +27,7 @@ internal class RenderingOfAdmonitionTest : RenderingTestBase() {
         assertThat(result).isEqualToConfluenceFormat(
             """
             <ac:structured-macro ac:name="$confluenceType"><ac:rich-text-body>
-            <p>Test block <strong>with</strong> formatting</p>
+            <p>Test block <strong>with</strong> formatting and line breaks in paragraph</p>
             <ol><li>and</li><li>lists</li></ol>
             </ac:rich-text-body></ac:structured-macro>
         """.trimIndent()

--- a/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfBasicTextFeatures.kt
+++ b/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfBasicTextFeatures.kt
@@ -1,0 +1,43 @@
+package com.github.zeldigas.text2confl.convert.asciidoc
+
+import assertk.assertThat
+import org.junit.jupiter.api.Test
+
+internal class RenderingOfBasicTextFeatures : RenderingTestBase() {
+
+    @Test
+    internal fun `Paragraphs and basic style details`() {
+        val result = toHtml(
+            """            
+            Test block **with** formatting
+            and *many* 
+            ^lines^.
+            
+            [%hardbreaks]
+            Test block 
+            **with enabled**
+            hard linebreaks.
+                        
+            Rubies are red, +
+            Topazes are blue.
+            
+            [.underline]#underlined text# and [.line-through]#strike through text#
+            is supported too!
+            
+            Consisting of multiple
+            paragraphs with image:https://myoctocat.com/assets/images/base-octocat.svg[Octocat,100]
+        """.trimIndent()
+        )
+
+        assertThat(result).isEqualToConfluenceFormat(
+            """          
+            <p>Test block <strong>with</strong> formatting and <strong>many</strong> <sup>lines</sup>.</p>
+            <p>Test block<br/> <strong>with enabled</strong><br/> hard linebreaks.</p>
+            <p>Rubies are red,<br/> Topazes are blue.</p>
+            <p><u>underlined text</u> and <del>strike through text</del> is supported too!</p>
+            <p>Consisting of multiple paragraphs with <ac:image ac:width="100" ac:alt="Octocat"><ri:url ri:value="https://myoctocat.com/assets/images/base-octocat.svg" /></ac:image></p>
+        """.trimIndent()
+        )
+    }
+
+}

--- a/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfLinksTest.kt
+++ b/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfLinksTest.kt
@@ -139,9 +139,7 @@ internal class RenderingOfLinksTest : RenderingTestBase() {
 
         assertThat(result).isEqualToConfluenceFormat(
             """
-            <p>Strong <strong><a href="https://example.org">Strong</a></strong>.
-            <em><a href="https://example.org/italics">Markdown Guide</a></em>.
-            Mixed content <a href="https://example.org/mixed"><code>code</code> and <strong>strong</strong> and <em>italic</em></a></p>
+            <p>Strong <strong><a href="https://example.org">Strong</a></strong>. <em><a href="https://example.org/italics">Markdown Guide</a></em>. Mixed content <a href="https://example.org/mixed"><code>code</code> and <strong>strong</strong> and <em>italic</em></a></p>
             <p>Link <a href="https://example.org/external"><del>strikethrough</del></a></p>
             <p>Link <a href="https://example.org/external"><del>abc</del></a></p>
         """.trimIndent(),


### PR DESCRIPTION
* Removing new lines in paragraph to make content
  1. more resistant to changes in line breaks.
  2. render properly in confluence cloud
* support for under line text
* asciidoc instance is now lazy, so if there is no adoc files it will not be created

Fixes #73
Fixes #74