### PR TITLE
fix(deps) : relocated dependency

### DIFF
--- a/confluence-client/pom.xml
+++ b/confluence-client/pom.xml
@@ -58,8 +58,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/convert/pom.xml
+++ b/convert/pom.xml
@@ -136,8 +136,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8-standalone</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,8 @@
                 <version>1.13.8</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8-standalone</artifactId>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock-standalone</artifactId>
                 <version>3.0.1</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
Wiremock was relocated to org.wiremock in 3.0.0. 

This suppresses warning during build about it.


See :   https://github.com/wiremock/wiremock/releases/tag/3.0.0

