### PR TITLE
Windows related fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - dependency updates:
   - migrated to `io.github.oshai:kotlin-logging-jvm`
+  - plantuml to 1.2023.12
+  
+### Fixed
+
+- Non-local links detection (may cause crash on Windows)
+- \[export-to-md] now always uses `/` as path separator for attachments
 
 ## 0.14.0 - 2023-09-20
 

--- a/cli/src/assembly/bin/text2confl
+++ b/cli/src/assembly/bin/text2confl
@@ -7,5 +7,7 @@ SCRIPT=$(readlink -f "$0")
 # Absolute path this script is in, thus /home/user/bin
 SCRIPTPATH=$(dirname "$SCRIPT")
 
-java -cp "$SCRIPTPATH/app/*:$SCRIPTPATH/lib/*" ${JAVA_OPTS:-} com.github.zeldigas.text2confl.cli.MainKt "$@"
+java -cp "$SCRIPTPATH/app/*:$SCRIPTPATH/lib/*" ${JAVA_OPTS:-} \
+  --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED \
+  com.github.zeldigas.text2confl.cli.MainKt "$@"
 

--- a/cli/src/assembly/bin/text2confl.cmd
+++ b/cli/src/assembly/bin/text2confl.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-java -cp "%~dp0app\*;%~dp0lib\*" com.github.zeldigas.text2confl.cli.MainKt %*
+java -cp "%~dp0app\*;%~dp0lib\*" --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED com.github.zeldigas.text2confl.cli.MainKt %*

--- a/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/AsciidocParser.kt
+++ b/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/AsciidocParser.kt
@@ -5,7 +5,7 @@ import com.vladsch.flexmark.util.sequence.Escaping.unescapeHtml
 import org.asciidoctor.*
 import org.asciidoctor.ast.Document
 import java.nio.file.Path
-import kotlin.io.path.Path
+import java.nio.file.Paths
 import kotlin.io.path.div
 
 
@@ -29,7 +29,7 @@ class AsciidocParser(
     private val templatesLocation: Path by lazy {
         val templateResources = AsciidocParser::class.java.getResource(TEMPLATES_LOCATION)!!.toURI()
         if (templateResources.scheme == "file") {
-            Path(templateResources.path)
+            Paths.get(templateResources)
         } else {
             val dest = config.workdir / "templates"
 

--- a/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/confluence/ReferenceProvider.kt
+++ b/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/confluence/ReferenceProvider.kt
@@ -39,14 +39,14 @@ class ReferenceProviderImpl(private val basePath: Path, documents: Map<Path, Pag
     ReferenceProvider {
 
     companion object {
-        private val URI_DETECTOR = "^[a-zA-Z][a-zA-Z0-9.+-]+:/{0,2}".toRegex()
+        private val URI_DETECTOR = "^[a-zA-Z][a-zA-Z0-9.+-]+:/{0,2}".toRegex(RegexOption.IGNORE_CASE)
     }
 
     private val normalizedDocs =
         documents.map { (path, header) -> path.relativeTo(basePath).normalize() to header }.toMap()
 
     override fun resolveReference(source: Path, refTo: String): Reference? {
-        if (URI_DETECTOR.matches(refTo)) return null
+        if (URI_DETECTOR.find(refTo) != null) return null
         if (refTo.startsWith("#")) return Anchor(refTo.substring(1))
 
         val parts = refTo.split("#", limit = 2)

--- a/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/markdown/ConfluenceStorageFormatConverters.kt
+++ b/convert/src/main/kotlin/com/github/zeldigas/text2confl/convert/markdown/ConfluenceStorageFormatConverters.kt
@@ -197,7 +197,7 @@ class ConfluenceNodeRenderer(options: DataHolder) : PhasedNodeRenderer, Attribut
         val resolvedLink = context.resolveLink(LinkType.IMAGE, node.url.unescape(), null, null)
         var linkUrl: String = resolvedLink.url
 
-        if (!node.urlContent.isEmpty) {
+        if (node.urlContent.isNotEmpty) {
             // reverse URL encoding of =, &
             val content = Escaping.percentEncodeUrl(node.urlContent).replace("+", "%2B").replace("%3D", "=")
                 .replace("%26", "&amp;")

--- a/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfDiagramsTest.kt
+++ b/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/asciidoc/RenderingOfDiagramsTest.kt
@@ -59,10 +59,11 @@ internal class RenderingOfDiagramsTest : RenderingTestBase() {
                 "auth-protocol.png" to Attachment.fromLink("auth-protocol.png", tempDir / "out" / "auth-protocol.png")
             )
         )
-        assertThat(result).isEqualToConfluenceFormat(
-            """
-            <p><ac:image ac:height="207" ac:width="290" ac:alt="auth protocol"><ri:attachment ri:filename="auth-protocol.png" /></ac:image></p>
+        assertThat(result).transform { it.replace("""ac:(height|width)="\d+"""".toRegex(), "ac:$1=\"?\"") }
+            .isEqualToConfluenceFormat(
+                """
+            <p><ac:image ac:height="?" ac:width="?" ac:alt="auth protocol"><ri:attachment ri:filename="auth-protocol.png" /></ac:image></p>
             """.trimIndent()
-        )
+            )
     }
 }

--- a/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/markdown/export/HtmlToMarkdownConverterTest.kt
+++ b/convert/src/test/kotlin/com/github/zeldigas/text2confl/convert/markdown/export/HtmlToMarkdownConverterTest.kt
@@ -29,7 +29,7 @@ class HtmlToMarkdownConverterTest {
 
     private fun readResoource(resource: String): String {
         return HtmlToMarkdownConverter::class.java.getResourceAsStream(resource)?.use {
-            String(it.readAllBytes())
+            String(it.readAllBytes()).replace("\r\n", "\n")
         } ?: throw IllegalStateException("Failed to load $resource")
     }
 }

--- a/core/src/main/kotlin/com/github/zeldigas/text2confl/core/export/PageExporter.kt
+++ b/core/src/main/kotlin/com/github/zeldigas/text2confl/core/export/PageExporter.kt
@@ -74,7 +74,8 @@ class PageExporter(internal val client: ConfluenceClient, internal val saveConte
                     writer.append('[')
                     writer.write(attachment.title)
                     writer.append("]: ")
-                    writer.append("${attachmentDir / attachment.title}")
+                    val attachmentLocation = path(attachmentDir, attachment).joinToString("/")
+                    writer.append(attachmentLocation)
                 }
             }
         }
@@ -82,6 +83,11 @@ class PageExporter(internal val client: ConfluenceClient, internal val saveConte
             (dest / "$sanitizedTitle.html").writer().use { it.write(content) }
         }
     }
+
+    private fun path(
+        attachmentDir: Path,
+        attachment: Attachment
+    ) = attachmentDir / attachment.title
 
     private fun writeHeader(writer: OutputStreamWriter, page: ConfluencePage) {
         writer.appendLine("""# ${page.title}""")

--- a/core/src/test/kotlin/com/github/zeldigas/text2confl/core/ContentValidatorImplTest.kt
+++ b/core/src/test/kotlin/com/github/zeldigas/text2confl/core/ContentValidatorImplTest.kt
@@ -49,6 +49,6 @@ internal class ContentValidatorImplTest {
                     )
             )
         }.isInstanceOf(ContentValidationFailedException::class)
-            .transform { it.errors }.isEqualTo(listOf("a/b.txt: err1", "c.txt: err2"))
+            .transform { it.errors }.isEqualTo(listOf("${Path.of("a", "b.txt")}: err1", "c.txt: err2"))
     }
 }


### PR DESCRIPTION
1. fixed line separator dependent tests
2. fixed export to markdown on Windows (backward slashes was used)
3. Fix for url detector regex
4. Stabilized test that depends on size of generated diagram